### PR TITLE
Fixed static magic method calls

### DIFF
--- a/data/Model.php
+++ b/data/Model.php
@@ -563,8 +563,7 @@ class Model extends \lithium\core\StaticObject {
 		if (isset($methods[$method]) && is_callable($methods[$method])) {
 			return call_user_func_array($methods[$method], $params);
 		}
-		$message = "Unhandled method call `{$method}`.";
-		throw new BadMethodCallException($message);
+		return self::__callStatic($method, $params);
 	}
 
 	/**


### PR DESCRIPTION
If a magic find is called such as first, __callStatic() will be called after __call() doesn't find any results and this will find the first magic method rather than an exception being thrown by __call() saying that the method doesn't exist.

Original issue - #851